### PR TITLE
chore: Use assertion to document command assumptions

### DIFF
--- a/src/main/java/com/oadultradeepfield/smartotter/command/AbstractListCommand.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/AbstractListCommand.java
@@ -36,6 +36,8 @@ public abstract class AbstractListCommand implements Executable {
 
     @Override
     public String execute(CommandContext context) {
+        assert context != null : "Context cannot be null";
+
         List<Task> tasks = getTasks(context);
 
         String result =

--- a/src/main/java/com/oadultradeepfield/smartotter/command/AddTaskCommand.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/AddTaskCommand.java
@@ -23,6 +23,8 @@ public abstract class AddTaskCommand implements Executable {
      */
     @Override
     public String execute(CommandContext context) {
+        assert context != null : "Context cannot be null";
+
         context.addTask(task);
         String message =
             """

--- a/src/main/java/com/oadultradeepfield/smartotter/command/ByeCommand.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/ByeCommand.java
@@ -23,6 +23,8 @@ public class ByeCommand implements Executable {
      */
     @Override
     public String execute(CommandContext context) {
+        assert context != null : "Context cannot be null";
+
         CustomIO.printPretty(SmartOtterConstant.FAREWELL_MESSAGE);
         return SmartOtterConstant.FAREWELL_MESSAGE;
     }

--- a/src/main/java/com/oadultradeepfield/smartotter/command/CommandParser.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/CommandParser.java
@@ -2,6 +2,7 @@ package com.oadultradeepfield.smartotter.command;
 
 import java.util.Set;
 import com.oadultradeepfield.smartotter.SmartOtterException;
+import com.oadultradeepfield.smartotter.util.CustomIO;
 
 /**
  * Parses user input into corresponding {@link Executable} instances.
@@ -16,6 +17,9 @@ public class CommandParser {
      *                             invalid for the matched command
      */
     public Executable parse(String input) throws SmartOtterException {
+        assert input.equals(CustomIO.sanitizeInput(input))
+            : "Input should be sanitized before parsing";
+
         String[] parts = input.split(" ", 2); // Split into maximum 2 parts;
         String commandWord = parts[0].toLowerCase();
 

--- a/src/main/java/com/oadultradeepfield/smartotter/command/DeleteCommand.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/DeleteCommand.java
@@ -38,6 +38,8 @@ public record DeleteCommand(int taskNumber) implements Executable {
      */
     @Override
     public String execute(CommandContext context) {
+        assert context != null : "Context cannot be null";
+
         // Convert 1-based to 0-based index and use getTask()
         Optional<Task> taskToDelete = context.getTask(taskNumber - 1);
 

--- a/src/main/java/com/oadultradeepfield/smartotter/command/MarkCommand.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/MarkCommand.java
@@ -38,6 +38,8 @@ public record MarkCommand(int taskNumber) implements Executable {
      */
     @Override
     public String execute(CommandContext context) {
+        assert context != null : "Context cannot be null";
+
         // Convert 1-based to 0-based index and use getTask()
         Optional<Task> taskToMark = context.getTask(taskNumber - 1);
 

--- a/src/main/java/com/oadultradeepfield/smartotter/command/UnmarkCommand.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/UnmarkCommand.java
@@ -38,6 +38,8 @@ public record UnmarkCommand(int taskNumber) implements Executable {
      */
     @Override
     public String execute(CommandContext context) {
+        assert context != null : "Context cannot be null";
+
         // Convert 1-based to 0-based index and use getTask()
         Optional<Task> taskToUnmark = context.getTask(taskNumber - 1);
 


### PR DESCRIPTION
## Description

- Some command parsing logic assumes invariants about the input, such as non-null arguments or membership in a predefined set of valid values.
- These assumptions are implicit in the code, which makes it harder for readers to reason about correctness and increases the risk of silent bugs if the assumptions are ever violated.
- Let's add assertions to explicitly document these invariants. Doing so clarifies the contract of each command, improves readability, and helps detect violations early during development and testing.
- Assertions are chosen over exceptions here because they express developer-level guarantees rather than user-facing validation.