### PR TITLE
feat: Support minor typos in command input

### DIFF
--- a/src/main/java/com/oadultradeepfield/smartotter/SmartOtterConstant.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/SmartOtterConstant.java
@@ -28,6 +28,12 @@ public final class SmartOtterConstant {
      */
     public static final String SAVE_PATH = "./data/smart_otter.txt";
 
+    /**
+     * Default maximum Levenshtein distance for fuzzy string matching.
+     * Allows up to 3 character differences (typos, insertions, deletions).
+     */
+    public static final int DEFAULT_FUZZY_MATCH_DISTANCE = 3;
+
     // Prevents instantiation
     private SmartOtterConstant() {
     }

--- a/src/main/java/com/oadultradeepfield/smartotter/SmartOtterConstant.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/SmartOtterConstant.java
@@ -30,9 +30,9 @@ public final class SmartOtterConstant {
 
     /**
      * Default maximum Levenshtein distance for fuzzy string matching.
-     * Allows up to 3 character differences (typos, insertions, deletions).
+     * Allows up to 2 character differences (typos, insertions, deletions).
      */
-    public static final int DEFAULT_FUZZY_MATCH_DISTANCE = 3;
+    public static final int DEFAULT_FUZZY_MATCH_DISTANCE = 2;
 
     // Prevents instantiation
     private SmartOtterConstant() {

--- a/src/main/java/com/oadultradeepfield/smartotter/command/CommandParser.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/CommandParser.java
@@ -38,19 +38,21 @@ public class CommandParser {
             }
         }
 
+        String commandName = type.name().toLowerCase();
+
         // Commands that do not take arguments
         Set<String> noArgCommands = Set.of("bye", "list", "today");
-        if (noArgCommands.contains(commandWord)) {
+        if (noArgCommands.contains(commandName)) {
             if (parts.length > 1) {
                 throw new SmartOtterException(
-                    "Command '%s' does not take any arguments".formatted(commandWord));
+                    "Command '%s' does not take any arguments".formatted(commandName));
             }
             return type.create("");
         }
 
         // Commands that require arguments
         if (parts.length < 2) {
-            throw new SmartOtterException("Command '%s' requires one argument".formatted(commandWord));
+            throw new SmartOtterException("Command '%s' requires one argument".formatted(commandName));
         }
 
         return type.create(parts[1]);

--- a/src/main/java/com/oadultradeepfield/smartotter/command/CommandParser.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/CommandParser.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import com.oadultradeepfield.smartotter.SmartOtterException;
 import com.oadultradeepfield.smartotter.util.CustomIO;
+import com.oadultradeepfield.smartotter.util.FuzzyMatcher;
 
 /**
  * Parses user input into corresponding {@link Executable} instances.
@@ -26,9 +27,15 @@ public class CommandParser {
         CommandType type = CommandType.fromKeyword(commandWord);
 
         if (type == null) {
-            throw new SmartOtterException(
-                "Unknown command: '%s'.\nI am not smart enough to understand,\nplease try again."
-                    .formatted(commandWord));
+            // Try fuzzy match
+            Set<String> keywords = CommandType.allKeywords();
+            String match = fuzzyMatchCommand(commandWord, keywords);
+            if (match != null) {
+                type = CommandType.fromKeyword(match);
+            } else {
+                throw new SmartOtterException(
+                    "Unknown command: '%s'. Please try again.".formatted(commandWord));
+            }
         }
 
         // Commands that do not take arguments
@@ -47,5 +54,18 @@ public class CommandParser {
         }
 
         return type.create(parts[1]);
+    }
+
+    private String fuzzyMatchCommand(String input, Set<String> commands) {
+        String bestMatch = null;
+
+        for (String cmd : commands) {
+            if (FuzzyMatcher.isMatched(cmd, input)) {
+                bestMatch = cmd;
+                break;
+            }
+        }
+
+        return bestMatch;
     }
 }

--- a/src/main/java/com/oadultradeepfield/smartotter/command/CommandType.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/command/CommandType.java
@@ -1,6 +1,8 @@
 package com.oadultradeepfield.smartotter.command;
 
 import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.oadultradeepfield.smartotter.SmartOtterException;
 
@@ -44,6 +46,19 @@ public enum CommandType {
 
     public Executable create(String input) throws SmartOtterException {
         return factory.create(input);
+    }
+
+    /**
+     * Returns all command keywords for fuzzy matching.
+     */
+    public static Set<String> allKeywords() {
+        return Arrays.stream(values())
+            .map(CommandType::keyword)
+            .collect(Collectors.toSet());
+    }
+
+    private String keyword() {
+        return keyword;
     }
 
     @FunctionalInterface

--- a/src/main/java/com/oadultradeepfield/smartotter/util/FuzzyMatcher.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/util/FuzzyMatcher.java
@@ -61,7 +61,7 @@ public class FuzzyMatcher {
         for (int i = 1; i <= s1.length(); i++) {
             for (int j = 1; j <= s2.length(); j++) {
                 if (s1.charAt(i - 1) == s2.charAt(j - 1)) {
-                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                    dp[i][j] = dp[i - 1][j - 1];
                 } else {
                     dp[i][j] = 1 + Math.min(
                         dp[i - 1][j - 1], // substitution

--- a/src/main/java/com/oadultradeepfield/smartotter/util/FuzzyMatcher.java
+++ b/src/main/java/com/oadultradeepfield/smartotter/util/FuzzyMatcher.java
@@ -1,0 +1,76 @@
+package com.oadultradeepfield.smartotter.util;
+
+import com.oadultradeepfield.smartotter.SmartOtterConstant;
+
+/**
+ * Utility class for fuzzy string matching using the Levenshtein distance algorithm.
+ * Provides methods to calculate edit distance between strings and perform approximate
+ * string matching with configurable tolerance.
+ */
+public class FuzzyMatcher {
+    // Prevents instantiation
+    private FuzzyMatcher() {
+    }
+
+    /**
+     * Performs fuzzy matching to determine if a keyword approximately matches
+     * any word in the given text within a specified edit distance tolerance.
+     * Both text and keyword are converted to lowercase for case-insensitive matching.
+     *
+     * @param text the text to search within, will be split into individual words
+     * @param keyword the keyword to search for
+     * @return true if any word in the text matches the keyword within the distance threshold
+     */
+    public static boolean isMatched(String text, String keyword) {
+        text = text.toLowerCase();
+        keyword = keyword.toLowerCase();
+
+        // Split text into words and check each against the keyword
+        for (String word : text.split("\\s+")) {
+            if (calculateLevenshteinDistance(word, keyword) <= SmartOtterConstant.DEFAULT_FUZZY_MATCH_DISTANCE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Calculates the Levenshtein distance between two strings.
+     * The Levenshtein distance is the minimum number of single-character edits
+     * (insertions, deletions, or substitutions) required to transform one string
+     * into another.
+     *
+     * @param s1 the first string to compare
+     * @param s2 the second string to compare
+     * @return the minimum edit distance between the two strings
+     */
+    private static int calculateLevenshteinDistance(String s1, String s2) {
+        // DP table where dp[i][j] represents distance between s1[0..i-1] and s2[0..j-1]
+        int[][] dp = new int[s1.length() + 1][s2.length() + 1];
+
+        // Initialize base cases: empty string to non-empty string
+        for (int i = 0; i <= s1.length(); i++) {
+            dp[i][0] = i;
+        }
+
+        for (int j = 0; j <= s2.length(); j++) {
+            dp[0][j] = j;
+        }
+
+        // Fill DP table using recurrence relation
+        for (int i = 1; i <= s1.length(); i++) {
+            for (int j = 1; j <= s2.length(); j++) {
+                if (s1.charAt(i - 1) == s2.charAt(j - 1)) {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = 1 + Math.min(
+                        dp[i - 1][j - 1], // substitution
+                        Math.min(dp[i - 1][j], dp[i][j - 1]) // deletion or insertion
+                    );
+                }
+            }
+        }
+
+        return dp[s1.length()][s2.length()];
+    }
+}


### PR DESCRIPTION
## Description

This update improves the SmartOtter command parser by adding fuzzy matching for command keywords. Users can now type commands with up to two character differences (insertions, deletions, or substitutions) and still have the correct command recognized.

**Tags:** `C-FriendlierSyntax`

## Key changes

- Added `FuzzyMatcher` utility implementing Levenshtein distance to compute approximate string matches.
- Updated `CommandParser` to fallback on fuzzy matching when the exact command keyword is not found.
- Added `CommandType.allKeywords()` to provide all command keywords for fuzzy matching.
- Maintains previous behaviour for argument validation and no-argument commands.

## Benefit

Improves usability by allowing minor typos in command input without breaking functionality.

## Example

- Input: "fnd homework" → Recognized as: "find homework"
- Input: "lits" → Recognized as: "

**Notes:** The maximum allowed edit distance is configurable via `SmartOtterConstant.DEFAULT_FUZZY_MATCH_DISTANCE` (currently 2).